### PR TITLE
Typo and event instead of conference

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -41,7 +41,7 @@ read -p "Enter smtp host: " smtpHost
 read -p "Enter smtp port: " smtpPort
 read -p "Enter smtp username: " smtpUsername
 read -p "Enter smtp password: " smtpPassword
-read -p "Enter SMTP encrytion tls/ssln/none: " smtpEncryption
+read -p "Enter SMTP encrytion tls/ssl/none: " smtpEncryption
 
 sed -i "s/<smtpHost>/$smtpHost/" .env.local
 sed -i "s/<smtpPort>/$smtpPort/" .env.local

--- a/src/Service/SubcriptionService.php
+++ b/src/Service/SubcriptionService.php
@@ -80,7 +80,7 @@ class SubcriptionService
             if (!$isOrganizer) {
                 $this->notifier->sendNotification(
                     $this->twig->render('email/subscriptionToRoom.html.twig', array('room' => $rooms, 'subsription' => $subscriber)),
-                    $this->translator->trans('Bestätigung ihrer Anmeldung zur Konferenz: {name}', array('{name}' => $rooms->getName())),
+                    $this->translator->trans('Bestätigung ihrer Anmeldung zur Veranstaltung: {name}', array('{name}' => $rooms->getName())),
                     $user,
                     $rooms->getStandort()
                 );
@@ -110,7 +110,7 @@ class SubcriptionService
             if (!$isOrganizer) {
                 $this->notifier->sendNotification(
                     $this->twig->render('email/subscriptionToRoom.html.twig', array('room' => $rooms, 'subsription' => $subscriber)),
-                    $this->translator->trans('Bestätigung ihrer Anmeldung zur Konferenz: {name}', array('{name}' => $rooms->getName())),
+                    $this->translator->trans('Bestätigung ihrer Anmeldung zur Veranstaltung: {name}', array('{name}' => $rooms->getName())),
                     $user,
                     $rooms->getStandort()
                 );

--- a/translations/messages+intl-icu.de.xlf
+++ b/translations/messages+intl-icu.de.xlf
@@ -93,9 +93,9 @@
         <source>Vielen Dank für die Anmeldung. Bitte bestätigen Sie Ihre Emailadresse in der Email, die wir ihnen zugeschickt haben.</source>
         <target>Vielen Dank für die Anmeldung. Bitte bestätigen Sie Ihre Emailadresse in der Email, die wir ihnen zugeschickt haben.</target>
       </trans-unit>
-      <trans-unit id="T.mgfUM" resname="Bestätigung ihrer Anmeldung zur Konferenz: {name}">
-        <source>Bestätigung ihrer Anmeldung zur Konferenz: {name}</source>
-        <target>Bestätigung ihrer Anmeldung zur Konferenz: {name}</target>
+      <trans-unit id="T.mgfUM" resname="Bestätigung ihrer Anmeldung zur Veranstaltung: {name}">
+        <source>Bestätigung ihrer Anmeldung zur Veranstaltung: {name}</source>
+        <target>Bestätigung ihrer Anmeldung zur Veranstaltung: {name}</target>
       </trans-unit>
       <trans-unit id="vnxSnbr" resname="Ungültige Email. Bitte überprüfen Sie ihre Emailadresse.">
         <source>Ungültige Email. Bitte überprüfen Sie ihre Emailadresse.</source>


### PR DESCRIPTION
Found a typo and in email it says "conferece" instead of "event"