### PR TITLE
send data, used by registration in email

### DIFF
--- a/templates/email/__roomInfo.html.twig
+++ b/templates/email/__roomInfo.html.twig
@@ -28,6 +28,16 @@
             {% endfor %}
         </ul>
     {% endif %}
+    <b>{{ 'Anmeldedaten'|trans }}</b>
+    <ul>
+    <li><b>{{ 'Name'|trans }}:</b> {{ user.firstName }} {{ user.lastName }}
+    <li><b>{{ 'E-Mail'|trans }}:</b> {{ user.email }}
+    <li><b>{{ 'Adresse'|trans }}:</b> {{ user.address }}
+    <li><b>{{ 'Telefon'|trans }}:</b> {{ user.phone }}
+    {% for ff in user.freeFieldsFromRoom(room) %}
+    <li><b>{{ ff.freefield.label }}:</b> {{ ff.answer }}<br>
+    {% endfor %}
+    </ul>
 {% endif %}
 <b>Standort:</b>
 <p>{{ room.standort.name }}<br>

--- a/templates/email/removeRoom.html.twig
+++ b/templates/email/removeRoom.html.twig
@@ -15,6 +15,16 @@
           Sie wurden von der Teilnehmerliste des Events: {name} entfernt. Dieses Event  kann aus dem Kalender entfernt werden.
         {% endtrans %}
     </p>
+    <b>{{ 'Anmeldedaten'|trans }}</b>
+    <ul>
+    <li><b>{{ 'Name'|trans }}:</b> {{ user.firstName }} {{ user.lastName }}
+    <li><b>{{ 'E-Mail'|trans }}:</b> {{ user.email }}
+    <li><b>{{ 'Adresse'|trans }}:</b> {{ user.address }}
+    <li><b>{{ 'Telefon'|trans }}:</b> {{ user.phone }}
+    {% for ff in user.freeFieldsFromRoom(room) %}
+    <li><b>{{ ff.freefield.label }}:</b> {{ ff.answer }}<br>
+    {% endfor %}
+    </ul>
     <b>
         {{ 'Name'|trans }}: {{ room.name }}
     </b>


### PR DESCRIPTION
send data, used by registration in email
If someone registers multple people to multiple events with its own email address, there is no way to check who was registered to which event. send all the data entered with the registration and delete-mail to be able to track this