### PR TITLE
room names with slash or backslach throw error for invalid file name

### DIFF
--- a/src/Controller/AtendeelistController.php
+++ b/src/Controller/AtendeelistController.php
@@ -22,6 +22,6 @@ class AtendeelistController extends AbstractController
         if(!$rooms){
             throw new NotFoundHttpException('Not found');
         }
-        return $this->file($teilnehmerExcelService->generateTeilnehmerliste($rooms), $rooms->getName() . '.xlsx', ResponseHeaderBag::DISPOSITION_INLINE);
+        return $this->file($teilnehmerExcelService->generateTeilnehmerliste($rooms), str_replace("\\", "_", str_replace("/", "_", $rooms->getName())) . '.xlsx', ResponseHeaderBag::DISPOSITION_INLINE);
     }
 }


### PR DESCRIPTION
room names with slash or backslach throw error for invalid file name when exorting attandee list
this replaces / and \ with _  to make exporting possible again